### PR TITLE
Music and Genre method classes

### DIFF
--- a/app/item.rb
+++ b/app/item.rb
@@ -3,7 +3,7 @@ class Item
   attr_reader :id, :archived, :genre, :author, :label
 
   # rubocop:disable Style/OptionalBooleanParameter
-  def initialize(name, publish_date, id = Random.rand(1..100_000), archived = false)
+  def initialize(name, publish_date, archived = false, id = Random.rand(1..100_000))
     @id = id
     @name = name
     @publish_date = publish_date # Time.new(year, month, day)

--- a/app/music_album.rb
+++ b/app/music_album.rb
@@ -9,4 +9,8 @@ class MusicAlbum < Item
     @on_spotify = on_spotify
   end
   # rubocop:enable Style/OptionalBooleanParameter
+
+  def can_be_archived?
+    super && @on_spotify
+  end
 end


### PR DESCRIPTION
In this pull request, I:
- Implemented methods:
    -`add_item` method in the `Genre` class (I had already done this on the last PR for association)
        - takes an instance of the Item class as an input
        - adds the input item to the collection of items
        - adds self as a property of the item object
    - `can_be_archived?()` method in the `MusicAlbum` class
        - overrides the method from the parent class
        - returns true if the parent's method returns true AND if `on_spotify` equals true
        - otherwise, it returns false